### PR TITLE
move jwx/internal/iter to this package for convenient codegen

### DIFF
--- a/mapiter/visitors.go
+++ b/mapiter/visitors.go
@@ -1,0 +1,34 @@
+package mapiter
+
+import (
+	"context"
+	"fmt"
+)
+
+// StrKeyVisitor is a custom visitor.
+// Whereas Visitor supports any type of key, this
+// visitor assumes the key is a string
+type StrKeyVisitor interface {
+	Visit(string, interface{}) error
+}
+
+type StrKeyVisitorFunc func(string, interface{}) error
+
+func (fn StrKeyVisitorFunc) Visit(s string, v interface{}) error {
+	return fn(s, v)
+}
+
+func WalkMap(ctx context.Context, src Source, visitor StrKeyVisitor) error {
+	return Walk(ctx, src, VisitorFunc(func(k, v interface{}) error {
+		//nolint:forcetypeassert
+		return visitor.Visit(k.(string), v)
+	}))
+}
+
+func AsStrIfaceMap(ctx context.Context, src Source) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if err := AsMap(ctx, src, &m); err != nil {
+		return nil, fmt.Errorf(`mapiter.AsMap failed: %w`, err)
+	}
+	return m, nil
+}

--- a/mapiter/visitors_test.go
+++ b/mapiter/visitors_test.go
@@ -1,0 +1,42 @@
+package mapiter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/iter/mapiter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsStrIfaceMap(t *testing.T) {
+	t.Run("Map-like object", func(t *testing.T) {
+		src := &MapLike{
+			Values: map[string]int{
+				"one":   1,
+				"two":   2,
+				"three": 3,
+				"four":  4,
+				"five":  5,
+			},
+		}
+
+		t.Run("returns identical map", func(t *testing.T) {
+			got, err := mapiter.AsStrIfaceMap(context.Background(), src)
+			if !assert.NoError(t, err, `AsStrIfaceMap returns identical MapLike object`) {
+				return
+			}
+
+			want := map[string]interface{}{
+				"one":   1,
+				"two":   2,
+				"three": 3,
+				"four":  4,
+				"five":  5,
+			}
+
+			if !assert.Equal(t, want, got, "maps should match") {
+				return
+			}
+		})
+	})
+}


### PR DESCRIPTION
moves [jwx/internal/iter](https://github.com/lestrrat-go/jwx/blob/92950642291a3af54c5f1455ec68e76b390587ae/internal/iter/mapiter.go) contents to this repo